### PR TITLE
fix: only trigger renovate config validation on actual changes

### DIFF
--- a/.github/workflows/renovate-config-validator.yml
+++ b/.github/workflows/renovate-config-validator.yml
@@ -3,7 +3,7 @@ name: Validate renovate config
 on:
   push:
     paths:
-      - 'renovate.json'
+      - renovate.json
 
 jobs:
   validate:


### PR DESCRIPTION
This should fix the failing runs on main when the file has not been changed.
