### PR TITLE
fix: use try_files to enable "virtual paths"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,5 @@ RUN npm run build
 FROM nginx:1.21.6-alpine
 ENV NODE_ENV production
 
+COPY default.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /app/build /usr/share/nginx/html

--- a/default.conf
+++ b/default.conf
@@ -1,0 +1,20 @@
+server {
+    listen       80;
+    server_name  localhost;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html;
+
+        try_files $uri $uri/ /index.html;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}


### PR DESCRIPTION
This uses nginx `try_files` to serve the requested file and fall back to `/index.html` if it does not exist.
