### PR TITLE
feat: set caching directives

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -7,12 +7,20 @@ server {
         index  index.html;
 
         try_files $uri $uri/ /index.html;
+
+        location ~*  \.(png|ico)$ {
+          add_header Cache-Control "public, max-age=604800";
+        }
+
+        location = /index.html {
+          add_header Cache-Control "no-cache";
+        }
+
+        location /static {
+          add_header Cache-Control "public, immutable, max-age=31536000";
+        }
     }
 
-    #error_page  404              /404.html;
-
-    # redirect server error pages to the static page /50x.html
-    #
     error_page   500 502 503 504  /50x.html;
     location = /50x.html {
         root   /usr/share/nginx/html;


### PR DESCRIPTION
This sets aggressive caching (1 year) for resources where the URL is hashed with the content, 7 days for images and no-cache for `index.html`.
