### PR TITLE
test: run renovate config validator only on changes to config or the test workflow

### DIFF
--- a/.github/workflows/renovate-config-validator.yml
+++ b/.github/workflows/renovate-config-validator.yml
@@ -2,8 +2,17 @@ name: Validate renovate config
 
 on:
   push:
+    branches:
+      - main
     paths:
       - renovate.json
+      - .github/workflows/renovate-config-validator.yml
+  pull_request:
+    branches:
+      - main
+    paths:
+      - renovate.json
+      - .github/workflows/renovate-config-validator.yml
 
 jobs:
   validate:


### PR DESCRIPTION
Tags do not evaluate path filters, therefore this gets a bit more complicated.
