### PR TITLE
chore: set semantic commit scope to default

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,6 @@
   "rangeStrategy": "pin",
   "rebaseWhen": "behind-base-branch",
   "semanticCommits": "enabled",
-  "semanticCommitScope": "feat",
   "packageRules": [
     {
       "matchManagers": ["npm", "github-actions", "pre-commit"],


### PR DESCRIPTION
Set the semantic scope back to "chore" as we use conventional commit style, not angular.
