### PR TITLE
fix: remove unnecessary query parameter

### DIFF
--- a/src/components/AccountForm.tsx
+++ b/src/components/AccountForm.tsx
@@ -38,7 +38,7 @@ const AccountForm = ({ budget, type, accounts }: Props) => {
   useEffect(() => {
     if (isPersisted) {
       accountApi
-        .get(accountId, budget)
+        .get(accountId)
         .then(data => {
           setAccount(data)
           setError('')
@@ -47,7 +47,7 @@ const AccountForm = ({ budget, type, accounts }: Props) => {
           setError(err.message)
         })
     }
-  }, [accountId, budget, isPersisted])
+  }, [accountId, isPersisted])
 
   const updateValue = (key: keyof Account, value: any) => {
     setHasUnsavedChanges(true)

--- a/src/components/CategoryForm.tsx
+++ b/src/components/CategoryForm.tsx
@@ -28,13 +28,13 @@ const CategoryForm = ({ budget }: { budget: Budget }) => {
     }
 
     categoryApi
-      .get(categoryId, budget)
+      .get(categoryId)
       .then(data => {
         setCategory(data)
         setError('')
       })
       .catch(err => setError(err.message))
-  }, [budget, categoryId, navigate])
+  }, [categoryId, navigate])
 
   const confirmDiscardingUnsavedChanges = (e: any) => {
     if (hasUnsavedChanges && !window.confirm(t('discardUnsavedChanges'))) {

--- a/src/components/EnvelopeForm.tsx
+++ b/src/components/EnvelopeForm.tsx
@@ -44,7 +44,7 @@ const EnvelopeForm = ({ budget, accounts }: Props) => {
     const promises = [categoryApi.getAll(budget).then(setCategories)]
 
     if (isPersisted) {
-      promises.push(envelopeApi.get(envelopeId, budget).then(setEnvelope))
+      promises.push(envelopeApi.get(envelopeId).then(setEnvelope))
     }
 
     Promise.all(promises)

--- a/src/components/TransactionForm.tsx
+++ b/src/components/TransactionForm.tsx
@@ -71,9 +71,7 @@ const TransactionForm = ({
     ]
 
     if (isPersisted) {
-      promises.push(
-        transactionApi.get(transactionId, budget).then(setTransaction)
-      )
+      promises.push(transactionApi.get(transactionId).then(setTransaction))
     }
 
     Promise.all(promises)

--- a/src/lib/api/base.ts
+++ b/src/lib/api/base.ts
@@ -18,8 +18,8 @@ const get = async (url: string) => {
 const api = (linkKey: string) => {
   return {
     getAll: (parent: ApiObject) => get(parent.links[linkKey]),
-    get: (id: UUID, parent: ApiObject) => {
-      const url = new URL(parent.links[linkKey])
+    get: (id: UUID) => {
+      const url = new URL(linkKey)
       url.pathname += `/${id}`
       return get(url.href)
     },


### PR DESCRIPTION
This removes the parent query parameter. It is unneeded as the backend API does ignore this parameter - resource IDs are always unique.

In the current state, this leads to the Form for the individual resources not rendering at all anymore and I have no idea why. Will ask @malfynnction for help before I sink an unncessary amount of time into it.
