### PR TITLE
test: use chrome to fix flaky Electron tests

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -27,6 +27,7 @@ jobs:
           start: npm start
           # Frontend runs on :3000, API on :8080
           wait-on: 'http://localhost:3000, http://localhost:8080'
+          browser: chrome
 
       - uses: actions/upload-artifact@v3.1.0
         if: failure()


### PR DESCRIPTION
Electron has problems with flaky tests. Since we do not run the frontend in Electron anywhere, use Chrome.
