### PR TITLE
test: fix flaky contains after save

### DIFF
--- a/cypress/e2e/budgets.cy.ts
+++ b/cypress/e2e/budgets.cy.ts
@@ -17,9 +17,9 @@ describe('Budget: Overview', () => {
     cy.getInputFor('Currency').type('€')
     cy.getInputFor('Note').type("We're all in this together!")
 
-    cy.contains('Save').click()
+    cy.clickAndWait('Save')
 
-    cy.get('h1').contains('Shared Household Budget', { timeout: 10000 })
+    cy.get('h1').contains('Shared Household Budget')
     cy.contains('Switch Budget')
 
     cy.getCookie('budgetId').should('exist')

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -4,6 +4,17 @@ Cypress.Commands.add('getInputFor', label =>
   cy.get('label').contains(label).siblings().find('input, textarea, select')
 )
 
+// Clicks the element and then tests that it does not exist any more.
+// As cypress retries for several seconds to fulfill this condition,
+// this effectively works as a „click and wait until the element is gone"
+//
+// We can easily use this to click the save button and wait for the next
+// page to be loaded before we proceed
+Cypress.Commands.add('clickAndWait', element => {
+  cy.contains(element).click()
+  cy.contains(element).should('not.exist')
+})
+
 Cypress.Commands.add('resetDb', () => {
   // TODO
 })

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -9,6 +9,7 @@ declare namespace Cypress {
      */
     getByTitle(title: string): Chainable<any>
     getInputFor(label: string): Chainable<any>
+    clickAndWait(element: string): Chainable<any>
     resetDb(): void
   }
 }


### PR DESCRIPTION
This introduces a 'wait for the next page to be loaded after save'
function for our tests.
