### PR TITLE
test: add account tests

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -33,21 +33,22 @@ jobs:
         image: ghcr.io/envelope-zero/backend:v1.0.2
         env:
           CORS_ALLOW_ORIGINS: http://localhost:3001
-          API_URL: http://localhost:8081
+          API_URL: http://localhost:3001/api
         ports:
-          - 8081:8080
+          - 8080:8080
 
     steps:
       - uses: actions/checkout@v3.0.2
 
       - uses: cypress-io/github-action@v4.2.0
         env:
-          REACT_APP_API_ENDPOINT: http://localhost:8081
           PORT: 3001
+          # The URL that the react-scripts dev server proxies /api to
+          API_URL: http://localhost:8080
         with:
           start: npm start
-          # Frontend runs on :3001, API on :8081
-          wait-on: 'http://localhost:3001, http://localhost:8081'
+          # Frontend runs on :3001, API on :8080
+          wait-on: 'http://localhost:3001, http://localhost:8080'
           browser: chrome
 
       - uses: actions/upload-artifact@v3.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,9 @@ npm run test
 
 # If you want to see your browser go wrooom and inspect the tests in detail, instead of npm run test, use
 npm run test:watch
+
+# To run only a specific test, use
+npm run test -- -s $PATH_TO_SPEC
 ```
 
 ## Commit messages

--- a/cypress/e2e/accounts.cy.ts
+++ b/cypress/e2e/accounts.cy.ts
@@ -1,0 +1,41 @@
+import { createBudget } from '../support/setup'
+
+describe('Account: Creation', () => {
+  beforeEach(() => {
+    // prepare & select a budget
+    cy.then(() => createBudget({ name: 'Account Test' })).then(() => {
+      cy.visit('/').get('h3').contains('Account Test').click()
+    })
+  })
+
+  it('can create an internal account for a budget', () => {
+    cy.contains('Accounts').click()
+    cy.getByTitle('Create Account').first().click()
+
+    cy.getInputFor('Name').type('Cash Test Account')
+    cy.getInputFor('On Budget').click({ force: true })
+    cy.getInputFor('Note').type('Are we testing the wallet now?')
+
+    cy.clickAndWait('Save')
+    cy.get('h3').contains('Cash Test Account')
+
+    cy.contains('External Accounts').click()
+    cy.contains('Cash Test Account').should('not.exist')
+  })
+
+  it('can create an external account for a budget', () => {
+    cy.contains('Accounts').click()
+    cy.contains('External Accounts').click()
+    cy.getByTitle('Create Account').click()
+
+    cy.getInputFor('Name').type('Cash Test Account')
+    cy.contains('On Budget').should('not.exist')
+    cy.getInputFor('Note').type('Are we testing the wallet now?')
+
+    cy.clickAndWait('Save')
+    cy.contains('Cash Test Account')
+
+    cy.contains('Own Accounts').click()
+    cy.contains('Cash Test Account').should('not.exist')
+  })
+})

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -17,5 +17,5 @@ Cypress.Commands.add('clickAndWait', element => {
 
 Cypress.Commands.add('resetDb', () => {
   // Delete all resources
-  cy.request('DELETE', 'http://localhost:8081/v1')
+  cy.request('DELETE', '/api/v1')
 })

--- a/cypress/support/setup.ts
+++ b/cypress/support/setup.ts
@@ -1,0 +1,8 @@
+import { UnpersistedBudget } from '../../src/types'
+import connectBudgetApi from '../../src/lib/api/budgets'
+
+export const createBudget = async (budget: UnpersistedBudget) => {
+  return connectBudgetApi().then(api => {
+    return api.createBudget(budget)
+  })
+}

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -8,10 +8,8 @@ services:
     image: ghcr.io/envelope-zero/backend:v1.0.2
     volumes:
       - ez-dev-data:/data
-    ports:
-      - '8080:8080'
     environment:
-      API_URL: http://localhost:8080
+      API_URL: http://localhost:3000/api
       CORS_ALLOW_ORIGINS: http://localhost:3000
 
   frontend:
@@ -23,5 +21,5 @@ services:
     volumes:
       - ./:/app
     environment:
-      REACT_APP_API_ENDPOINT: http://localhost:8080
-      BROWSER: none # Don't open a browser
+      # Don't open a browser, we're in a container
+      BROWSER: none

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -2,10 +2,8 @@ version: '3'
 services:
   backend:
     image: ghcr.io/envelope-zero/backend:v1.0.2
-    ports:
-      - '8081:8080'
     environment:
-      API_URL: http://localhost:8081
+      API_URL: http://localhost:3001/api
       CORS_ALLOW_ORIGINS: http://localhost:3001
 
   frontend:
@@ -17,5 +15,7 @@ services:
     volumes:
       - ./:/app
     environment:
-      REACT_APP_API_ENDPOINT: http://localhost:8081
-      BROWSER: none # Don't open a browser
+      # Set the web socket port to 0 to use the port the browser uses
+      WDS_SOCKET_PORT: 0
+      # Don't open a browser, we're in a container
+      BROWSER: none

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@types/node": "18.7.16",
         "@types/react": "18.0.18",
         "@types/react-dom": "18.0.6",
+        "http-proxy-middleware": "^2.0.6",
         "i18next": "21.9.1",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -9151,9 +9152,9 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.4.tgz",
-      "integrity": "sha512-m/4FxX17SUvz4lJ5WPXOHDUuCwIqXLfLHs1s0uZ3oYjhoXlx9csYxaOa0ElDEJ+h8Q4iJ1s+lTMbiCa4EXIJqg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
+      "integrity": "sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==",
       "dependencies": {
         "@types/http-proxy": "^1.17.8",
         "http-proxy": "^1.18.1",
@@ -24426,9 +24427,9 @@
       }
     },
     "http-proxy-middleware": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.4.tgz",
-      "integrity": "sha512-m/4FxX17SUvz4lJ5WPXOHDUuCwIqXLfLHs1s0uZ3oYjhoXlx9csYxaOa0ElDEJ+h8Q4iJ1s+lTMbiCa4EXIJqg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
+      "integrity": "sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==",
       "requires": {
         "@types/http-proxy": "^1.17.8",
         "http-proxy": "^1.18.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@types/node": "18.7.16",
     "@types/react": "18.0.18",
     "@types/react-dom": "18.0.6",
+    "http-proxy-middleware": "^2.0.6",
     "i18next": "21.9.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/src/lib/api/base.ts
+++ b/src/lib/api/base.ts
@@ -1,9 +1,7 @@
 import { ApiObject, UUID, Budget, FilterOptions } from '../../types'
 import { checkStatus, parseJSON } from '../fetch-helper'
 
-const endpoint =
-  (process.env.REACT_APP_API_ENDPOINT || window.location.origin + '/api') +
-  '/v1'
+const endpoint = window.location.origin + '/api/v1'
 
 const getApiInfo = async () => {
   return fetch(endpoint).then(checkStatus).then(parseJSON)

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -1,0 +1,12 @@
+const { createProxyMiddleware } = require('http-proxy-middleware')
+
+module.exports = function (app) {
+  app.use(
+    '/api',
+    createProxyMiddleware({
+      target: process.env.API_URL || 'http://backend:8080',
+      changeOrigin: true,
+      pathRewrite: { '^/api': '' },
+    })
+  )
+}


### PR DESCRIPTION
This

* configures a development proxy
* removes the env variable `REACT_APP_API_ENDPOINT` in favor of using the proxy
* adds helper functions for testing
* adds tests for accounts

Note: The proxy setup is in `setupProxy.js` as create-react-app does not support proxy setup with typescript (yet).