### PR TITLE
feat: send API requests to backend

### DIFF
--- a/cypress/e2e/api.cy.ts
+++ b/cypress/e2e/api.cy.ts
@@ -1,0 +1,18 @@
+describe('API: Load from Server', () => {
+  it('loads the API from the server instead of redirecting to /', () => {
+    cy.request({
+      url: '/api',
+      headers: {
+        accept: 'application/json',
+      },
+    }).then(response => {
+      expect(response.status).to.eq(200)
+
+      // The body should only have one key: links
+      expect(response.body).to.have.keys(['links'])
+
+      // The links object can have any key, but must contain docs, v1 and version
+      expect(response.body.links).to.contain.keys(['docs', 'v1', 'version'])
+    })
+  })
+})

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -165,6 +165,11 @@ const App = () => {
               )}
             </>
           )}
+          {/*
+            This path does nothing, which leads to requests being passed
+            to the server, which is exactly what we want for /api
+          */}
+          <Route path="api" />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Route>
       </Routes>


### PR DESCRIPTION
This introduces a new route for /api that does nothing
With this route, requests for /api get send to the server.

This enables users to open the API in their browser without
annoying workarounds.

Fixes #108.