### PR TITLE
fix: show budget switch if selected budget can't be loaded

### DIFF
--- a/cypress/e2e/budgets.cy.ts
+++ b/cypress/e2e/budgets.cy.ts
@@ -1,3 +1,5 @@
+import { createBudget } from '../support/setup'
+
 describe('Budget: Overview', () => {
   it('successfully loads', () => {
     cy.visit('/')
@@ -43,5 +45,16 @@ describe('Budget: Switch', () => {
     cy.contains('Switch Budget').click()
     cy.get('h3').contains('Second Budget').click()
     cy.get('h1').contains('Second Budget')
+  })
+
+  it('is shown if the selected budget was deleted in the background', () => {
+    cy.wrap(createBudget({ name: 'Might delete later' }))
+    cy.visit('/')
+    cy.contains('Might delete later').click()
+    cy.resetDb()
+    cy.visit('/')
+    cy.awaitLoading() // loading the selected budget -> fail
+    cy.awaitLoading() // loading all existing budgets (for budget switch)
+    cy.contains('No budgets have been created yet. Create a new one below!')
   })
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,10 +32,12 @@ const App = () => {
   const [budget, setBudget] = useState<Budget>()
   const [accounts, setAccounts] = useState<Account[]>([])
   const [error, setError] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
   const budgetId = cookie.get('budgetId')
 
   useEffect(() => {
     if (typeof budgetId !== 'undefined') {
+      setIsLoading(true)
       connectBudgetApi().then(api => {
         api
           .getBudget(budgetId)
@@ -43,10 +45,12 @@ const App = () => {
             setBudget(data)
             loadAccounts(data)
             setError('')
+            setIsLoading(false)
           })
           .catch(err => {
             selectBudget()
             setError(err.message)
+            setIsLoading(false)
           })
       })
     }
@@ -81,12 +85,13 @@ const App = () => {
                 path="budgets/:budgetId"
                 element={<BudgetForm selectBudget={selectBudget} />}
               />
-              {typeof budgetId === 'undefined' ? (
+              {typeof budgetId === 'undefined' ||
+              typeof budget === 'undefined' ? (
                 <Route
                   path="/"
                   element={<BudgetSwitch selectBudget={selectBudget} />}
                 />
-              ) : typeof budget === 'undefined' ? (
+              ) : isLoading ? (
                 <Route path="*" element={<LoadingSpinner />} />
               ) : (
                 <>


### PR DESCRIPTION
closes #290 