### PR TITLE
fix: SameSite attribute is always required

### DIFF
--- a/src/lib/cookie.ts
+++ b/src/lib/cookie.ts
@@ -13,7 +13,7 @@ const set = (key: string, value: string) => {
 }
 
 const erase = (key: string) => {
-  document.cookie = key + '=; Max-Age=-99999999;'
+  document.cookie = key + '=; Max-Age=-99999999; SameSite=Strict'
 }
 
 const cookie = {


### PR DESCRIPTION
The SameSite attribute is always required when sending a cookie.
