### PR TITLE
test: run cypress 5 times in CI to detect flakey tests

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -46,6 +46,7 @@ jobs:
           # The URL that the react-scripts dev server proxies /api to
           API_URL: http://localhost:8080
         with:
+          command: npm run test:ci
           start: npm start
           # Frontend runs on :3001, API on :8080
           wait-on: 'http://localhost:3001, http://localhost:8080'

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
       "devDependencies": {
         "autoprefixer": "10.4.11",
         "cypress": "10.8.0",
+        "cypress-repeat": "^2.3.3",
         "eslint-config-prettier": "8.5.0",
         "postcss": "8.4.16",
         "prettier": "2.7.1",
@@ -6508,6 +6509,33 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/cypress-repeat": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/cypress-repeat/-/cypress-repeat-2.3.3.tgz",
+      "integrity": "sha512-DoPiN5A/SMC9p6B2lRbvOxQvQUS6LO8Zeblkc3ZQQl5cQMmGBa15EOMLdBpQ1ctjOgssvcYawodBkxiNMHI49g==",
+      "dev": true,
+      "dependencies": {
+        "arg": "5.0.2",
+        "bluebird": "3.7.2",
+        "debug": "4.3.4",
+        "dotenv": "8.2.0"
+      },
+      "bin": {
+        "cypress-repeat": "index.js"
+      },
+      "peerDependencies": {
+        "cypress": ">=5.3.0"
+      }
+    },
+    "node_modules/cypress-repeat/node_modules/dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/cypress/node_modules/@types/node": {
@@ -22599,6 +22627,26 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
+        }
+      }
+    },
+    "cypress-repeat": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/cypress-repeat/-/cypress-repeat-2.3.3.tgz",
+      "integrity": "sha512-DoPiN5A/SMC9p6B2lRbvOxQvQUS6LO8Zeblkc3ZQQl5cQMmGBa15EOMLdBpQ1ctjOgssvcYawodBkxiNMHI49g==",
+      "dev": true,
+      "requires": {
+        "arg": "5.0.2",
+        "bluebird": "3.7.2",
+        "debug": "4.3.4",
+        "dotenv": "8.2.0"
+      },
+      "dependencies": {
+        "dotenv": {
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+          "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "autoprefixer": "10.4.11",
     "cypress": "10.8.0",
+    "cypress-repeat": "^2.3.3",
     "eslint-config-prettier": "8.5.0",
     "postcss": "8.4.16",
     "prettier": "2.7.1",
@@ -49,6 +50,7 @@
     "server:test:restart": "docker-compose --project-name frontend-test --file docker-compose-test.yml restart",
     "server:test:logs": "docker-compose --project-name frontend-test --file docker-compose-test.yml logs --follow",
     "test": "cypress run",
+    "test:ci": "cypress-repeat run -n 5",
     "test:watch": "cypress open",
     "eject": "react-scripts eject",
     "format": "prettier --write ."


### PR DESCRIPTION
With this, all tests run 5 times in the CI. The command exits with an error if any tests fail or with success when none fails.

This is one possible way of repeating tests, others are described in https://www.cypress.io/blog/2020/12/03/retry-rerun-repeat/#repeat.

This increases cypress test run time a lot, but will detect flakes much better than we currently do (i.e. by accident).

@malfynnction what do you think?
