### PR TITLE
test: fix flaky tests

### DIFF
--- a/cypress/e2e/budgets.cy.ts
+++ b/cypress/e2e/budgets.cy.ts
@@ -44,11 +44,11 @@ describe('Budget: Switch', () => {
   it('can switch between budgets', () => {
     cy.visit('/budgets/new')
     cy.getInputFor('Name').type('First Budget')
-    cy.contains('Save').click()
+    cy.clickAndWait('Save')
 
     cy.visit('/budgets/new')
     cy.getInputFor('Name').type('Second Budget')
-    cy.contains('Save').click()
+    cy.clickAndWait('Save')
 
     cy.contains('Switch Budget').click()
     cy.get('h3').contains('First Budget').click()

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -2,4 +2,5 @@ import './commands'
 
 beforeEach(() => {
   cy.resetDb()
+  cy.visit('/')
 })


### PR DESCRIPTION
This fixes some flakyness by always visiting a page to trigger loading.
In another test case, it fixes flakyness by using clickAndWait instead
of click to save resources.
