### PR TITLE
fix: throw non-json error responses correctly

### DIFF
--- a/src/lib/fetch-helper.js
+++ b/src/lib/fetch-helper.js
@@ -2,10 +2,23 @@ const checkStatus = async response => {
   if (response.ok) {
     return response
   } else {
-    const error = await parseJSON(response)
-    throw new Error(error.error)
+    const text = await parseText(response)
+
+    let error = ''
+
+    // Try to parse the error as JSON, if it fails just use the
+    // plain text of the response
+    try {
+      error = JSON.parse(text).error
+    } catch (e) {
+      error = 'Unknown error: ' + text
+    }
+
+    // Throw the message of the parsed error object
+    throw error
   }
 }
 const parseJSON = response => response.json()
+const parseText = response => response.text()
 
 export { checkStatus, parseJSON }


### PR DESCRIPTION
If the HTTP response is not ok and the body is not json, we now throw
the text of the body as error message instead of an object (which would
lead to rendering an empty page).

Resolves #247.