### PR TITLE
test: add wait commands for loading

### DIFF
--- a/cypress/e2e/dashboard.cy.ts
+++ b/cypress/e2e/dashboard.cy.ts
@@ -13,6 +13,7 @@ describe('Dashboard', () => {
       ).then(() => {
         cy.visit('/').get('h3').contains('Dashboard Test').click()
         cy.getCookie('budgetId').should('exist')
+        cy.awaitLoading()
       })
     })
   })

--- a/cypress/e2e/transactions.cy.ts
+++ b/cypress/e2e/transactions.cy.ts
@@ -167,7 +167,7 @@ describe('Transaction: Creation', () => {
 
     cy.clickAndWait('Save')
     cy.contains('Burgers').click()
-    cy.contains('Repeat Transaction').click()
+    cy.clickAndWait('Repeat Transaction')
 
     cy.getInputFor('Note').should('have.value', 'Burgers')
     cy.getInputFor('Amount').should('have.value', '5')


### PR DESCRIPTION
This fixes multiple issues where cypress would check
for content before loading was finished.
