### PR TITLE
feat: add spent for whole month

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -34,7 +34,7 @@ jobs:
     # Current backend version as service container
     services:
       backend:
-        image: ghcr.io/envelope-zero/backend:v1.12.2
+        image: ghcr.io/envelope-zero/backend:v1.13.0
         env:
           CORS_ALLOW_ORIGINS: http://localhost:3001
           API_URL: http://localhost:3001/api

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -5,7 +5,7 @@ volumes:
 
 services:
   backend:
-    image: ghcr.io/envelope-zero/backend:v1.12.2
+    image: ghcr.io/envelope-zero/backend:v1.13.0
     volumes:
       - ez-dev-data:/data
     environment:

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   backend:
-    image: ghcr.io/envelope-zero/backend:v1.12.2
+    image: ghcr.io/envelope-zero/backend:v1.13.0
     environment:
       API_URL: http://localhost:3001/api
       CORS_ALLOW_ORIGINS: http://localhost:3001

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -211,8 +211,16 @@ const Dashboard = ({ budget }: DashboardProps) => {
                           )}
                         </td>
                         <td
-                          className={`hidden md:table-cell whitespace-nowrap px-3 pb-3 text-sm font-semibold text-right`}
-                        ></td>
+                          className={`hidden md:table-cell whitespace-nowrap px-3 pb-3 text-sm font-semibold text-right ${
+                            budgetMonth.spent < 0 ? 'positive' : 'text-gray-500'
+                          }`}
+                        >
+                          {formatMoney(
+                            budgetMonth.spent,
+                            budget.currency,
+                            'auto'
+                          )}
+                        </td>
                         <td
                           className={`whitespace-nowrap pl-3 pr-4 sm:pr-6 pb-3 text-sm font-semibold text-right ${
                             budgetMonth.balance < 0

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -109,6 +109,7 @@ export type BudgetMonth = ApiObject & {
   name: string
   month: string // e.g. '2022-09-01T00:00:00Z' for the whole month of September 2022
   budgeted: number
+  spent: number
   income: number
   available: number
   balance: number


### PR DESCRIPTION
With the release of the backend in v1.13.0, including https://github.com/envelope-zero/backend/pull/474, we can add the spent sum for the month.
