### PR TITLE
feat: do not show 0 amounts for individual envelopes in spent and balance columns

### DIFF
--- a/src/components/CategoryMonth.tsx
+++ b/src/components/CategoryMonth.tsx
@@ -104,14 +104,14 @@ const CategoryMonth = ({
               allocation < 0 ? 'negative' : 'text-gray-500'
             }`}
           >
-            {formatMoney(allocation, budget.currency, 'auto')}
+            {formatMoney(allocation, budget.currency, { signDisplay: 'auto' })}
           </td>
           <td
             className={`hidden md:table-cell whitespace-nowrap px-1 pb-2 text-sm text-right ${
               spent < 0 ? 'positive' : 'text-gray-500'
             }`}
           >
-            {formatMoney(spent, budget.currency, 'auto')}
+            {formatMoney(spent, budget.currency, { signDisplay: 'auto' })}
           </td>
           <td
             className={`whitespace-nowrap pl-1 pr-4 sm:pr-6 pb-2 text-sm text-right ${

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -156,7 +156,9 @@ const Dashboard = ({ budget }: DashboardProps) => {
                 budgetMonth.available >= 0 ? 'positive' : 'negative'
               } text-xl font-bold`}
             >
-              {formatMoney(budgetMonth.available, budget.currency, 'auto')}
+              {formatMoney(budgetMonth.available, budget.currency, {
+                signDisplay: 'auto',
+              })}
             </div>
             <div className="text-gray-500 font-medium">
               {t('dashboard.available')}
@@ -204,22 +206,18 @@ const Dashboard = ({ budget }: DashboardProps) => {
                               : 'text-gray-500'
                           }`}
                         >
-                          {formatMoney(
-                            budgetMonth.budgeted,
-                            budget.currency,
-                            'auto'
-                          )}
+                          {formatMoney(budgetMonth.budgeted, budget.currency, {
+                            signDisplay: 'auto',
+                          })}
                         </td>
                         <td
                           className={`hidden md:table-cell whitespace-nowrap px-3 pb-3 text-sm font-semibold text-right ${
                             budgetMonth.spent < 0 ? 'positive' : 'text-gray-500'
                           }`}
                         >
-                          {formatMoney(
-                            budgetMonth.spent,
-                            budget.currency,
-                            'auto'
-                          )}
+                          {formatMoney(budgetMonth.spent, budget.currency, {
+                            signDisplay: 'auto',
+                          })}
                         </td>
                         <td
                           className={`whitespace-nowrap pl-3 pr-4 sm:pr-6 pb-3 text-sm font-semibold text-right ${

--- a/src/components/EnvelopeMonth.tsx
+++ b/src/components/EnvelopeMonth.tsx
@@ -143,7 +143,9 @@ const EnvelopeMonth = ({
         ) : (
           <div onClick={() => editEnvelope(envelope.id)}>
             <span className="pr-1">
-              {formatMoney(envelope.allocation, budget.currency, 'auto')}
+              {formatMoney(envelope.allocation, budget.currency, {
+                signDisplay: 'auto',
+              })}
             </span>
             <button
               aria-label={t('editObject', {
@@ -163,14 +165,17 @@ const EnvelopeMonth = ({
           envelope.spent < 0 ? 'positive' : 'text-gray-500'
         }`}
       >
-        {formatMoney(envelope.spent, budget.currency, 'auto')}
+        {formatMoney(envelope.spent, budget.currency, {
+          signDisplay: 'auto',
+          hideZero: true,
+        })}
       </td>
       <td
         className={`whitespace-nowrap pl-1 pr-4 sm:pr-6 py-4 text-sm text-right ${
           envelope.balance < 0 ? 'negative' : 'text-gray-500'
         }`}
       >
-        {formatMoney(envelope.balance, budget.currency)}
+        {formatMoney(envelope.balance, budget.currency, { hideZero: true })}
       </td>
     </tr>
   )

--- a/src/components/LatestTransactions.tsx
+++ b/src/components/LatestTransactions.tsx
@@ -77,11 +77,9 @@ const LatestTransactions = ({
                             className={`px-2 inline-flex text-xs leading-5 font-bold rounded-full ${color}`}
                           >
                             {sign}
-                            {formatMoney(
-                              transaction.amount,
-                              budget.currency,
-                              'never'
-                            )}
+                            {formatMoney(transaction.amount, budget.currency, {
+                              signDisplay: 'never',
+                            })}
                           </p>
                         </div>
                         <div

--- a/src/components/TransactionsList.tsx
+++ b/src/components/TransactionsList.tsx
@@ -109,7 +109,7 @@ const TransactionsList = ({ budget, accounts }: Props) => {
                                     {formatMoney(
                                       transaction.amount,
                                       budget.currency,
-                                      'never'
+                                      { signDisplay: 'never' }
                                     )}
                                   </p>
                                 </div>

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -3,10 +3,17 @@ const locale = 'en-US' // TODO: user preference
 const formatMoney = (
   amount: number,
   currency: string = '',
-  signDisplay: Intl.NumberFormatOptions['signDisplay'] = 'exceptZero'
+  options: {
+    signDisplay?: Intl.NumberFormatOptions['signDisplay']
+    hideZero?: boolean
+  } = {}
 ) => {
+  if (options.hideZero && amount == 0) {
+    return
+  }
+
   return `${new Intl.NumberFormat(locale, {
-    signDisplay: signDisplay,
+    signDisplay: options.signDisplay || 'exceptZero',
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,
   }).format(amount)} ${currency}`

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -8,7 +8,7 @@ const formatMoney = (
     hideZero?: boolean
   } = {}
 ) => {
-  if (options.hideZero && amount == 0) {
+  if (options.hideZero && amount === 0) {
     return
   }
 


### PR DESCRIPTION
With this change, the columns “Spent” and “Balance” for an individual envelope in the dashboard stay empty if the number is zero.

Categories will still show a zero amount when collapsed.
