### PR TITLE
feat: add VSCode launch config to debug with Firefox

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "firefox",
+      "request": "launch",
+      "name": "frontend debug",
+      "url": "http://localhost:3000",
+      "webRoot": "${workspaceFolder}"
+    }
+  ]
+}


### PR DESCRIPTION
Adds a launch config for Firefox.

With this, you can launch the VSCode debugger, which launches Firefox and enables breakpoints, variable inspection etc.

