### PR TITLE
feat: do not show sign for positive balances

### DIFF
--- a/cypress/e2e/dashboard.cy.ts
+++ b/cypress/e2e/dashboard.cy.ts
@@ -77,7 +77,7 @@ describe('Dashboard', () => {
     cy.get('[aria-label*="Edit Allocation for First Envelope"]').click()
     cy.getInputFor('Allocation for First Envelope').type('12.00')
     cy.get('[aria-label="Save"]').click()
-    cy.contains('+12.00')
+    cy.contains('12.00')
     cy.contains('-12.00 Available to budget')
 
     // close input without saving
@@ -105,7 +105,7 @@ describe('Dashboard', () => {
     cy.get('[aria-label*="Edit Allocation for Third Envelope"]').click()
     cy.getInputFor('Allocation for Third Envelope').type('30.00')
     cy.get('[aria-label="Save"]').click()
-    cy.contains('+30.00')
+    cy.contains('30.00')
     cy.contains('-20.00 Available to budget')
 
     // collapse category

--- a/src/components/CategoryMonth.tsx
+++ b/src/components/CategoryMonth.tsx
@@ -107,7 +107,7 @@ const CategoryMonth = ({
               Number(balance) < 0 ? 'negative' : 'text-gray-500'
             }`}
           >
-            {formatMoney(balance, budget.currency)}
+            {formatMoney(balance, budget.currency, { signDisplay: 'auto' })}
           </td>
         </tr>
       )}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -232,7 +232,9 @@ const Dashboard = ({ budget }: DashboardProps) => {
                               : 'text-gray-500'
                           }`}
                         >
-                          {formatMoney(budgetMonth.balance, budget.currency)}
+                          {formatMoney(budgetMonth.balance, budget.currency, {
+                            signDisplay: 'auto',
+                          })}
                         </td>
                       </tr>
                       {budgetMonth.categories.map(category => (

--- a/src/components/EnvelopeMonth.tsx
+++ b/src/components/EnvelopeMonth.tsx
@@ -175,7 +175,10 @@ const EnvelopeMonth = ({
           Number(envelope.balance) < 0 ? 'negative' : 'text-gray-500'
         }`}
       >
-        {formatMoney(envelope.balance, budget.currency, { hideZero: true })}
+        {formatMoney(envelope.balance, budget.currency, {
+          hideZero: true,
+          signDisplay: 'auto',
+        })}
       </td>
     </tr>
   )


### PR DESCRIPTION
We currently show a sign for positive envelope balances. This is not needed.
