### PR TITLE
fix: set step='any' on number inputs by default

### DIFF
--- a/src/components/FormField.tsx
+++ b/src/components/FormField.tsx
@@ -20,34 +20,40 @@ const FormField = ({
   children,
   hideLabel,
   compact,
-}: Props) => (
-  <div className={`form-field--wrapper ${compact ? 'border-0' : ''}`}>
-    <label
-      htmlFor={name}
-      className={`form-field--label ${hideLabel ? 'sr-only' : ''}`}
-    >
-      {label}
-    </label>
+}: Props) => {
+  if (type === 'number' && typeof options?.step === 'undefined') {
+    options = { ...options, step: 'any' }
+  }
 
-    <div
-      className={`input--outer ${
-        hideLabel ? 'sm:col-span-3' : 'sm:col-span-2'
-      }`}
-    >
-      <div className="input--inner">
-        <input
-          className="input"
-          type={type}
-          name={name}
-          id={name}
-          value={value}
-          onChange={onChange}
-          {...options}
-        />
-        {children}
+  return (
+    <div className={`form-field--wrapper ${compact ? 'border-0' : ''}`}>
+      <label
+        htmlFor={name}
+        className={`form-field--label ${hideLabel ? 'sr-only' : ''}`}
+      >
+        {label}
+      </label>
+
+      <div
+        className={`input--outer ${
+          hideLabel ? 'sm:col-span-3' : 'sm:col-span-2'
+        }`}
+      >
+        <div className="input--inner">
+          <input
+            className="input"
+            type={type}
+            name={name}
+            id={name}
+            value={value}
+            onChange={onChange}
+            {...options}
+          />
+          {children}
+        </div>
       </div>
     </div>
-  </div>
-)
+  )
+}
 
 export default FormField


### PR DESCRIPTION
To avoid fun browser errors like this one:
![image](https://user-images.githubusercontent.com/24372341/211191228-3fb2ea89-68a1-46fd-a19b-044c1b4d0393.png)


This fixes #637 