### PR TITLE
chore(deps): use all renovate replacement and workaround presets

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,11 @@
 {
-  "extends": ["group:monorepos", "group:recommended"],
+  "extends": [
+    "group:monorepos",
+    "group:recommended",
+    "replacements:all",
+    "workarounds:all",
+    ":ignoreModulesAndTests"
+  ],
   "dependencyDashboard": true,
   "platformAutomerge": true,
   "pre-commit": {
@@ -26,6 +32,15 @@
       "matchPackageNames": ["ghcr.io/envelope-zero/backend"],
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true
+    }
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": ["^Dockerfile$"],
+      "matchStrings": ["FROM node:(?<currentValue>.*?)-alpine"],
+      "depNameTemplate": "node",
+      "datasourceTemplate": "node",
+      "versioningTemplate": "node"
     }
   ]
 }


### PR DESCRIPTION
This updates the renovate config to use some more recommended templates.

It also includes configuration with a regexManager that will apply node versioning to the OCI image used in the `Dockerfile` to keep it in sync with the node version from `package.json`.
With this configuration, it will always use the **Active LTS** version.
