### PR TITLE
chore: update documentation and instructions link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Envelope Zero frontend
 
+Envelope Zero is fundamentally rooted in two ideas:
+
+- Using the [envelope method](https://en.wikipedia.org/wiki/Envelope_system) to budget expenses into envelopes.
+- Zero Based Budeting, meaning that you assign all your money to an envelope. Saving for a vacation? Create an envelope and archive it after your vacation. Rent? Create an envelope that gets a fixed amount of money added every month.
+
 Check out the documentation at [envelope-zero.org](https://envelope-zero.org)!
 
 ## Deployment

--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # Envelope Zero frontend
 
-Envelope Zero is fundamentally rooted in two ideas:
-
-- Using the [envelope method](https://en.wikipedia.org/wiki/Envelope_system) to budget expenses into envelopes.
-- Zero Based Budeting, meaning that you assign all your money to an envelope. Saving for a vacation? Create an envelope and archive it after your vacation. Rent? Create an envelope that gets a fixed amount of money added every month.
+Check out the documentation at [envelope-zero.org](https://envelope-zero.org)!
 
 ## Deployment
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -57,7 +57,7 @@
       "importBudget": "Import Budget",
       "importInstead": "Import an existing budget from YNAB 4 instead",
       "shortDescription": "Import an existing budget from YNAB 4",
-      "description": "You can import your YNAB 4 budget here. This will create a new EZ budget with all your transactions, categories, and accounts from YNAB so that you can continue right where you left off.\nSee <a class='link-blue' href='https://github.com/envelope-zero/backend/blob/main/docs/import.md#how-to-import'>here</a> for instructions on where to find your YNAB data file.",
+      "description": "You can import your YNAB 4 budget here. This will create a new EZ budget with all your transactions, categories, and accounts from YNAB so that you can continue right where you left off.\nSee <a class='link-blue' href='https://l.envelope-zero.org/import-ynab4'>here</a> for instructions on where to find your YNAB data file.",
       "importedBudget": "Imported Budget",
       "budgetName": "Budget Name",
       "file": "File"


### PR DESCRIPTION
THis updates the link pointing to the import documentation to a short link that we can update when moving documentation.

Details about the short link service are in https://envelope-zero.org/docs/project-infrastructure/#short-link-service
