### PR TITLE
feat: filter transactions by month when clicking a link on the dashboard

### DIFF
--- a/cypress/e2e/dashboard.cy.ts
+++ b/cypress/e2e/dashboard.cy.ts
@@ -247,7 +247,7 @@ describe('Dashboard', () => {
     cy.contains('September Transaction').should('exist')
     cy.contains('October Transaction').should('not.exist')
 
-    cy.contains('From 9/1/2023').should('exist')
-    cy.contains('Until 9/30/2023').should('exist')
+    cy.contains('From 9/1/2023')
+    cy.contains('Until 9/30/2023')
   })
 })

--- a/src/components/EnvelopeMonth.tsx
+++ b/src/components/EnvelopeMonth.tsx
@@ -65,7 +65,13 @@ const EnvelopeMonth = ({
     )
   }
 
-  const month = translatedMonthFormat.format(new Date(envelope.month))
+  const month = new Date(envelope.month)
+  const localMonth = translatedMonthFormat.format(month)
+  const lastDay = new Date(
+    month.getFullYear(),
+    month.getMonth() + 1,
+    0
+  ).toISOString()
 
   return (
     <tr
@@ -157,7 +163,7 @@ const EnvelopeMonth = ({
             aria-label={t('editObject', {
               object: t('dashboard.allocationForEnvelopeMonth', {
                 envelope: envelope.name,
-                month: month,
+                month: localMonth,
               }),
             })}
           >
@@ -172,7 +178,9 @@ const EnvelopeMonth = ({
             : 'text-gray-500 dark:text-gray-400'
         }`}
       >
-        <Link to={`/transactions?envelope=${envelope.id}`}>
+        <Link
+          to={`/transactions?envelope=${envelope.id}&fromDate=${envelope.month}&untilDate=${lastDay}`}
+        >
           {formatMoney(envelope.spent, budget.currency, {
             hideZero: true,
           })}
@@ -185,7 +193,9 @@ const EnvelopeMonth = ({
             : 'text-gray-500 dark:text-gray-400'
         }`}
       >
-        <Link to={`/transactions?envelope=${envelope.id}`}>
+        <Link
+          to={`/transactions?envelope=${envelope.id}&fromDate=${envelope.month}&untilDate=${lastDay}`}
+        >
           {formatMoney(envelope.balance, budget.currency, {
             hideZero: true,
             signDisplay: 'auto',


### PR DESCRIPTION
This adds the `fromDate` and `untilDate` to the transaction list links generated on the dashboard.
With this, when clicking on an amount on the dashboard, only transactions for the month the user
is currently viewing will be shown in the transaction list.
