### PR TITLE
fix: set availability date to the current date on transaction duplication

### DIFF
--- a/src/components/TransactionForm.tsx
+++ b/src/components/TransactionForm.tsx
@@ -95,6 +95,7 @@ const TransactionForm = ({ budget, accounts, reloadAccounts }: Props) => {
             ...template,
             id: undefined,
             date: new Date().toISOString(),
+            availableFrom: new Date().toISOString(),
           })
         })
       )


### PR DESCRIPTION
The backend enforces the availability date to be no earlier than the month of the
transaction from version v3.1.4 on with https://github.com/envelope-zero/backend/pull/789.

The frontend does not set this correctly yet when duplicating transactions.

This PR fixes that behavior.
