### PR TITLE
chore: use node versioning for node Docker image

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,3 +11,8 @@ repos:
     rev: v3.0.3
     hooks:
       - id: prettier
+
+  - repo: https://github.com/renovatebot/pre-commit-hooks
+    rev: 37.45.0
+    hooks:
+      - id: renovate-config-validator

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "group:monorepos",
     "group:recommended",
@@ -32,6 +33,12 @@
       "matchPackageNames": ["ghcr.io/envelope-zero/backend"],
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true
+    },
+    {
+      "description": "Use node versioning for node Docker image",
+      "matchDepNames": "node",
+      "matchManagers": "dockerfile",
+      "versioning": "node"
     }
   ],
   "regexManagers": [


### PR DESCRIPTION
This will keep all used node versions aligned.
