### PR TITLE
chore: disable renovate dockerfile manager for node

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -35,13 +35,13 @@
       "automerge": true
     },
     {
-      "description": "Use node versioning for node Docker image",
+      "description": "Disable dockerfile manager for node, version is managed with customManager",
       "matchDepNames": "node",
       "matchManagers": "dockerfile",
-      "versioning": "node"
+      "enabled": false
     }
   ],
-  "regexManagers": [
+  "customManagers": [
     {
       "fileMatch": ["^Dockerfile$"],
       "matchStrings": ["FROM node:(?<currentValue>.*?)-alpine"],


### PR DESCRIPTION
These upgrades are handled with a customManager, therefore the Dockerfile
manager is conflicting.
