### PR TITLE
fix: reduce user confusion by adding information about the date/month picker

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,9 @@ repos:
     hooks:
       - id: prettier
 
-  - repo: https://github.com/renovatebot/pre-commit-hooks
-    rev: 37.53.1
+  # Explicitly not using the renovate upstream hook because for some reason installing it is
+  # excruciatingly slow (> 10 minutes in some cases)
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.27.1
     hooks:
-      - id: renovate-config-validator
+      - id: check-renovate

--- a/src/components/TransactionForm.tsx
+++ b/src/components/TransactionForm.tsx
@@ -384,7 +384,11 @@ const TransactionForm = ({ budget, accounts, reloadAccounts }: Props) => {
                 name="availableFrom"
                 label={t('transactions.availableFrom')}
                 note={`(${t('transactions.onlyRelevantForIncome')})`}
-                tooltip={t('transactions.availableFromExplanation')}
+                tooltip={`${t('transactions.availableFromExplanation')}${
+                  isSupported.inputTypeMonth()
+                    ? ''
+                    : t('transactions.availableFromMonthField')
+                }`}
                 value={(isSupported.inputTypeMonth()
                   ? (date: string) => monthYearFromDate(new Date(date))
                   : (date: string) =>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -114,6 +114,7 @@
     "availableFrom": "Available From",
     "onlyRelevantForIncome": "Only relevant for income",
     "availableFromExplanation": "The month in which this income should be made available to budget.\n Use this setting to prevent allocating funds that are not yet available.\n\nFor example, if your salary is paid at the end of the month, you might want to set this to the following month.",
+    "availableFromMonthField": "\n\nThis field is fixed to the first of the month since the availability is always for a whole month. Your browser does not support a month input field, therefore Envelope Zero displays a date input.",
     "note": "Note",
     "destinationAccountId": "Destination",
     "sourceAccountId": "Source",


### PR DESCRIPTION
This adds information about why the "Available From" field is a date picker on
browsers that do not support `input type="month"`.

On Firefox:

![image](https://github.com/envelope-zero/frontend/assets/7683567/2f075751-2379-4c08-90ac-9d6e08dc7c40)

On Chromium:

![image](https://github.com/envelope-zero/frontend/assets/7683567/2207f6fd-909d-4eb5-8641-29c8b91ed78a)
