### PR TITLE
test: run all dashboard tests

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v5.1.0
         with:
-          push: true
+          push: contains('refs/tags/', github.ref) && github.repository == "envelope-zero/frontend"
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v5.1.0
         with:
-          push: contains('refs/tags/', github.ref) && github.repository == "envelope-zero/frontend"
+          push: ${{ github.repository == 'envelope-zero/frontend' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -2,6 +2,7 @@ name: Test, build and push
 
 on:
   push:
+  pull_request:
 
 concurrency:
   group: ${{ github.ref }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v5.1.0
         with:
-          push: ${{ github.repository == 'envelope-zero/frontend' }}
+          push: ${{ github.repository_owner == 'envelope-zero' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v5.1.0
         with:
-          push: ${{ github.repository_owner == 'envelope-zero' }}
+          push: ${{ github.repository_owner == 'envelope-zero' && contains('refs/tags/', github.ref) }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |

--- a/cypress/e2e/dashboard.cy.ts
+++ b/cypress/e2e/dashboard.cy.ts
@@ -237,6 +237,7 @@ describe('Dashboard', () => {
 
     // We need to reload to load everything from the backend, not just the transactions
     cy.reload()
+    cy.get('h1').contains('Dashboard Test')
 
     // We created transactions for August, September and October 2023, visit September to verify
     cy.visit('#', { qs: { month: '2023-09' } })

--- a/cypress/e2e/dashboard.cy.ts
+++ b/cypress/e2e/dashboard.cy.ts
@@ -191,7 +191,7 @@ describe('Dashboard', () => {
   })
 
   // This needs to be a declared function to have a binding for 'this'
-  it.only('links to the filtered transaction list', function () {
+  it('links to the filtered transaction list', function () {
     cy.wrap(
       Cypress.Promise.all([
         createAccount({ name: 'Internal' }, this.budget),

--- a/cypress/e2e/dashboard.cy.ts
+++ b/cypress/e2e/dashboard.cy.ts
@@ -69,9 +69,9 @@ describe('Dashboard', () => {
     cy.url().should('include', '?month=2019-12')
 
     cy.get('#month').click()
-    cy.get('input#month').type('2022-03-01')
+    cy.get('input#month').type('2022-03')
     cy.awaitLoading()
-    cy.get('#month').should('have.value', '2022-03-01')
+    cy.get('#month').should('have.value', '2022-03')
     cy.contains('Feb')
     cy.contains('Apr')
   })


### PR DESCRIPTION
With https://github.com/envelope-zero/frontend/pull/1092 a test with `cy.only` was added. This runs only this test and skips all other dashboard tests.