### PR TITLE
ci: clean up old images

### DIFF
--- a/.github/workflows/cleanup-images.yml
+++ b/.github/workflows/cleanup-images.yml
@@ -1,0 +1,23 @@
+name: Clean images
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Clean up at 4:30 on Monday
+    - cron: '30 4 * * 1'
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+
+    steps:
+      - uses: actions/delete-package-versions@0d39a63126868f5eefaa47169615edd3c0f61e20 # v4.1.1
+        with:
+          package-name: frontend
+          package-type: container
+          min-versions-to-keep: 0
+
+          # Keep semver versions
+          ignore-versions: '^\d+\.\d+\.\d+$'


### PR DESCRIPTION
This adds a CI job to clean up old image versions that are not semver.
