### PR TITLE
feature: select text of input field when setting an allocation

### DIFF
--- a/cypress/e2e/dashboard.cy.ts
+++ b/cypress/e2e/dashboard.cy.ts
@@ -104,6 +104,16 @@ describe('Dashboard', () => {
     cy.contains('-30.00').should('not.exist')
     cy.contains('12.00')
 
+    // select content of allocation input field when focusing it
+    cy.get('[aria-label*="Edit Allocation for First Envelope"]').click()
+    cy.getInputFor('Set to amount').clear().type('1337')
+    cy.get('button[type="submit"]').click()
+    cy.awaitLoading()
+    cy.get('[aria-label*="Edit Allocation for First Envelope"]').click()
+    cy.getInputFor('Set to amount').type('12')
+    cy.getInputFor('Set to amount').should('have.value', '12')
+    cy.get('button[type="submit"]').click()
+
     // set allocation for second envelope
     cy.get('[aria-label*="Edit Allocation for Second Envelope"]').click()
     cy.getInputFor('Set to amount').clear().type('-22.00')

--- a/src/components/AllocationInputs.tsx
+++ b/src/components/AllocationInputs.tsx
@@ -37,6 +37,9 @@ const AllocationInputs = ({
             bigDecimal.subtract(e.target.value, savedAllocation)
           )
         }}
+        onFocus={e => {
+          e.target.select()
+        }}
         compact
       >
         <InputCurrency currency={budget.currency} />

--- a/src/components/FormField.tsx
+++ b/src/components/FormField.tsx
@@ -8,6 +8,7 @@ type Props = {
   value?: string
   options?: { [option: string]: string | boolean }
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
+  onFocus?: (e: React.FocusEvent<HTMLInputElement>) => void
   children?: React.ReactNode
   hideLabel?: boolean
   compact?: boolean
@@ -22,6 +23,7 @@ const FormField = ({
   value,
   options,
   onChange,
+  onFocus,
   children,
   hideLabel,
   compact,
@@ -69,6 +71,7 @@ const FormField = ({
             id={name}
             value={value}
             onChange={onChange}
+            onFocus={onFocus}
             {...options}
           />
           {children}


### PR DESCRIPTION
When using the "Set amount" field it is usually intended to override the value. By selecting the text onFocus the user can start typing right away.