### PR TITLE
ci: use cypress cloud

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -58,13 +58,19 @@ jobs:
         ports:
           - 8080:8080
 
+    strategy:
+      fail-fast: false # https://github.com/cypress-io/github-action/issues/48
+      matrix:
+        containers: [1, 2, 3, 4, 5, 6] # Use 6 parallel instances as per Cypress Cloud recommendation
     steps:
-      - uses: actions/checkout@v4.1.1
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
 
-      - name: set npm auth
+      - name: Set npm auth
         run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> ~/.npmrc
 
-      - uses: cypress-io/github-action@v6.6.0
+      - name: Run cypress
+        uses: cypress-io/github-action@v6.6.0
         with:
           start: npm run start-ci
           # Frontend runs on :3000, API on :8080
@@ -72,17 +78,13 @@ jobs:
           browser: chromium
           headed: true
 
-      - uses: actions/upload-artifact@v3.1.3
-        if: failure()
-        with:
-          name: cypress-screenshots
-          path: cypress/screenshots
+          # Records to Cypress Cloud
+          record: true
+          parallel: true
 
-      - uses: actions/upload-artifact@v3.1.3
-        if: failure()
-        with:
-          name: cypress-videos
-          path: cypress/videos
+        env:
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build-and-push-image:
     needs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,8 @@ The default frontend configuration and default backend configuration match up, s
 
 Please write tests when you add features and add regression tests for bug fixes. We use [cypress](https://docs.cypress.io) for end-to-end testing of the frontend, see the [cypress/e2e](cypress/e2e/) directory for all tests.
 
+When tests run in the CI, they are uploaded to [Cypress Cloud](https://cloud.cypress.io/projects/uc2vus), where we can analyze them more easily.
+
 You can run the tests as follows:
 
 ```sh

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  projectId: 'uc2vus', // Cypress Cloud config
   video: true,
   e2e: {
     baseUrl: 'http://localhost:3000',


### PR DESCRIPTION
This adds configuration for cypress cloud.

- Tests will continue to log to the GitHub actions logs
- Tests are running in parallel (currently 6 runners with a matrix job, configured as recommended by Cypress Cloud). This results in much faster run times than before.
- The Envelope Zero project in Cypress Cloud is public: https://cloud.cypress.io/projects/uc2vus
