### PR TITLE
ci: fix missing push in ci

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -12,6 +12,9 @@ on:
       - '*'
   pull_request:
 
+  # Enables us to manually trigger the CI for earlier tags
+  workflow_dispatch:
+
 concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
@@ -120,7 +123,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v5.1.0
         with:
-          push: ${{ github.repository_owner == 'envelope-zero' && contains('refs/tags/', github.ref) }}
+          push: ${{ github.repository_owner == 'envelope-zero' && contains(github.ref, 'refs/tags/') }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |


### PR DESCRIPTION
This fixes the CI not releasing new image versions on tags.
