### PR TITLE
feat!: use API v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Check the table below for the minimal required [backend](https://github.com/enve
 | 0.9.0            | v0.22.0                          |
 | 1.9.0            | v2.0.0                           |
 | 2.0.0            | v3.21.1                          |
+| 3.0.0            | v4.2.2                           |
 
 ## Contributing
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -6,6 +6,7 @@ volumes:
 services:
   backend:
     image: ghcr.io/envelope-zero/backend:v4.2.2
+    user: root
     volumes:
       - ez-dev-data:/data
     ports:

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -6,6 +6,7 @@ volumes:
 services:
   backend:
     image: ghcr.io/envelope-zero/backend:v4.2.2
+    user: root
     volumes:
       - ez-production-data:/data
     environment:

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -2,6 +2,7 @@ version: '3'
 services:
   backend:
     image: ghcr.io/envelope-zero/backend:v4.2.2
+    user: root
     ports:
       - 8081:8080
     environment:

--- a/src/components/OwnAccountsList.tsx
+++ b/src/components/OwnAccountsList.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next'
 import { Link, useSearchParams } from 'react-router-dom'
 import { useEffect, useState } from 'react'
-import { Translation, Budget, Account, AccountComputedData } from '../types'
+import { Translation, Budget, Account } from '../types'
 import { PencilIcon } from '@heroicons/react/24/solid'
 import {
   ArchiveBoxIcon,
@@ -40,7 +40,7 @@ const OwnAccountsList = ({ budget }: Props) => {
       .getAll(budget, { external: false, archived: Boolean(archived) })
       .then(data => {
         // Create list of all IDs
-        const ids: string = data.map((account: Account) => {
+        const ids = data.map((account: Account) => {
           return account.id
         })
 
@@ -55,7 +55,7 @@ const OwnAccountsList = ({ budget }: Props) => {
           return data.map((account: Account) => ({
             ...account,
             computedData: computedData.find(
-              (e: AccountComputedData) => e.id == account.id
+              (e: Account['computedData']) => e?.id == account.id
             ),
           }))
         })
@@ -140,20 +140,22 @@ const OwnAccountsList = ({ budget }: Props) => {
                         {account.note}
                       </p>
                     ) : null}
-                    <div
-                      className={`${
-                        Number(account.computedData?.balance) >= 0
-                          ? 'text-lime-600'
-                          : 'text-red-600'
-                      } mt-2 text-lg`}
-                    >
-                      <strong>
-                        {formatMoney(
-                          account.computedData?.balance,
-                          budget.currency
-                        )}
-                      </strong>
-                    </div>
+                    {account.computedData ? (
+                      <div
+                        className={`${
+                          Number(account.computedData.balance) >= 0
+                            ? 'text-lime-600'
+                            : 'text-red-600'
+                        } mt-2 text-lg`}
+                      >
+                        <strong>
+                          {formatMoney(
+                            account.computedData.balance,
+                            budget.currency
+                          )}
+                        </strong>
+                      </div>
+                    ) : null}
                   </Link>
                 </li>
               ))}

--- a/src/components/TransactionForm.tsx
+++ b/src/components/TransactionForm.tsx
@@ -62,7 +62,7 @@ const TransactionForm = ({ budget, setNotification }: Props) => {
     useState<UnpersistedAccount>()
   const [destinationAccountToCreate, setDestinationAccountToCreate] =
     useState<UnpersistedAccount>()
-  const [recentEnvelopes, setRecentEnvelopes] = useState([] as RecentEnvelope[])
+  const [recentEnvelopes, setRecentEnvelopes] = useState<RecentEnvelope[]>([])
 
   const isPersisted =
     typeof transactionId !== 'undefined' && transactionId !== 'new'

--- a/src/components/TransactionForm.tsx
+++ b/src/components/TransactionForm.tsx
@@ -328,6 +328,8 @@ const TransactionForm = ({ budget, setNotification }: Props) => {
                         }
                       })
                     )
+                  } else if (!account.external) {
+                    setRecentEnvelopes([])
                   }
 
                   Promise.all(envelopePromises).then(() =>

--- a/src/components/TransactionForm.tsx
+++ b/src/components/TransactionForm.tsx
@@ -351,15 +351,12 @@ const TransactionForm = ({ budget, setNotification }: Props) => {
               groups={[
                 {
                   title: t('transactions.recentEnvelopes'),
-                  items: envelopes.filter(envelope => {
-                    // TODO: I'm sure this can be done better
-                    for (let recentEnvelope of recentEnvelopes) {
-                      if (recentEnvelope.id === envelope.id) {
-                        return true
-                      }
-                    }
-                    return false
-                  }),
+                  items: recentEnvelopes.map(
+                    recentEnvelope =>
+                      envelopes.find(
+                        envelope => envelope.id === recentEnvelope.id
+                      ) as Envelope
+                  ),
                 },
                 ...groupedEnvelopes,
               ]}

--- a/src/lib/api/base.ts
+++ b/src/lib/api/base.ts
@@ -11,7 +11,7 @@ const get = async (url: string, body?: BodyInit) => {
   // HTTP GET supports request body, but JS fetch does not
   // Therefore, the backend exposes certain endpoints as
   // HTTP POST
-  const method = body != null ? 'POST' : 'GET'
+  const method = typeof body === 'undefined' ? 'GET' : 'POST'
 
   return fetch(url, { method: method, body: body })
     .then(checkStatus)

--- a/src/lib/api/base.ts
+++ b/src/lib/api/base.ts
@@ -1,14 +1,19 @@
 import { ApiObject, UUID, Budget, FilterOptions } from '../../types'
 import { checkStatus, parseJSON } from '../fetch-helper'
 
-const endpoint = window.location.origin + '/api/v3'
+const endpoint = window.location.origin + '/api/v4'
 
 const getApiInfo = async () => {
   return fetch(endpoint).then(checkStatus).then(parseJSON)
 }
 
-const get = async (url: string) => {
-  return fetch(url)
+const get = async (url: string, body?: BodyInit) => {
+  // HTTP GET supports request body, but JS fetch does not
+  // Therefore, the backend exposes certain endpoints as
+  // HTTP POST
+  const method = body != null ? 'POST' : 'GET'
+
+  return fetch(url, { method: method, body: body })
     .then(checkStatus)
     .then(parseJSON)
     .then(data => data.data)

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,7 +1,7 @@
 const locale = 'en-US' // TODO: user preference
 
 const formatMoney = (
-  amount: string = '0',
+  amount: string,
   currency: string = '',
   options: {
     signDisplay?: Intl.NumberFormatOptions['signDisplay']

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,7 +1,7 @@
 const locale = 'en-US' // TODO: user preference
 
 const formatMoney = (
-  amount: string,
+  amount: string = '0',
   currency: string = '',
   options: {
     signDisplay?: Intl.NumberFormatOptions['signDisplay']

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -47,12 +47,23 @@ export type BudgetApiConnection = {
   createBudget: (data: UnpersistedBudget) => Promise<Budget>
 }
 
+export type AccountComputedData = {
+  id: string
+  balance: string
+  reconciledBalance: string
+}
+
+export type AccountRecentEnvelopes = {
+  recentEnvelopes: {
+    name: string
+    id: UUID
+  }[]
+}
+
 export type Account = UnpersistedAccount &
   ApiObject & {
-    balance: string
-    reconciledBalance: string
     budgetId: UUID
-    recentEnvelopes: UUID[]
+    computedData?: AccountComputedData
   }
 
 export type ApiResponse<T> = {
@@ -178,3 +189,8 @@ export type Theme = 'dark' | 'light' | 'default'
 export type QuickAllocationMode =
   | 'ALLOCATE_LAST_MONTH_BUDGET'
   | 'ALLOCATE_LAST_MONTH_SPEND'
+
+export type RecentEnvelope = {
+  name: string
+  id: UUID
+}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -47,23 +47,14 @@ export type BudgetApiConnection = {
   createBudget: (data: UnpersistedBudget) => Promise<Budget>
 }
 
-export type AccountComputedData = {
-  id: string
-  balance: string
-  reconciledBalance: string
-}
-
-export type AccountRecentEnvelopes = {
-  recentEnvelopes: {
-    name: string
-    id: UUID
-  }[]
-}
-
 export type Account = UnpersistedAccount &
   ApiObject & {
     budgetId: UUID
-    computedData?: AccountComputedData
+    computedData?: {
+      id: string
+      balance: string
+      reconciledBalance: string
+    }
   }
 
 export type ApiResponse<T> = {


### PR DESCRIPTION
With this, the frontend uses API v4. API v4 removes computed endpoints
from resource collection endpoints and exposes these at new endpoints.

This requires a few more API calls from frontend, but greatly improves
performance since we only request data when it's needed.

BREAKING CHANGE: With this change, the frontend requires backend version v4.2.2.
