### PR TITLE
chore(deps): install ynap-parsers from npmjs

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -38,9 +38,6 @@ jobs:
           node-version: '20'
           cache: 'npm'
 
-      - name: set npm auth
-        run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> ~/.npmrc
-
       - name: install node modules
         run: npm ci
 
@@ -70,11 +67,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
 
-      - name: Set npm auth
-        run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> ~/.npmrc
-
       - name: Run cypress
         uses: cypress-io/github-action@v6.6.1
+        timeout-minutes: 5
         with:
           start: npm run start-ci
           # Frontend runs on :3000, API on :8080
@@ -137,4 +132,3 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             VITE_VERSION=${{ github.ref_name }}
-            GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -51,7 +51,7 @@ jobs:
     # Current backend version as service container
     services:
       backend:
-        image: ghcr.io/envelope-zero/backend:v5.1.0
+        image: ghcr.io/envelope-zero/backend:v5.1.3
         env:
           CORS_ALLOW_ORIGINS: http://localhost:3000
           API_URL: http://localhost:3000/api
@@ -74,8 +74,6 @@ jobs:
           start: npm run start-ci
           # Frontend runs on :3000, API on :8080
           wait-on: 'http://localhost:3000, http://localhost:8080'
-          browser: chromium
-          headed: true
 
           # Records to Cypress Cloud
           record: true

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-@envelope-zero:registry=https://npm.pkg.github.com

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,6 @@ Contributions are welcome. Please note the [Code of Conduct](CODE_OF_CONDUCT.md)
 You will need to:
 
 - Install [pre-commit](https://pre-commit.com/)
-- Set up a GitHub Personal Access Token to read from the GitHub package repository. Follow the steps in https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry#authenticating-with-a-personal-access-token.
 
 Once these steps are done, run `make setup` to perform the repository setup.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ npm run start:test
 npm run test
 
 # If you want to see your browser go wrooom and inspect the tests in detail, use this.
-# Note that you'll need to select Chrome or Chromium as browser since neither Electron nor Firefox support Month pickers as of now
+# Note that you'll need to select Electron
 npm run test:watch
 
 # To run only a specific test, use

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,7 @@ WORKDIR /app
 COPY package.json package-lock.json /app/
 COPY patches /app/patches
 
-ARG GITHUB_TOKEN
-RUN echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> ~/.npmrc && \
-    npm install --production
+RUN npm install --production
 
 # Copy app files
 COPY src /app/src

--- a/cypress/e2e/dashboard.cy.ts
+++ b/cypress/e2e/dashboard.cy.ts
@@ -50,28 +50,31 @@ describe('Dashboard', () => {
     })
   })
 
-  const date = new Date()
-  const currentMonth = `${date.getFullYear()}-${
-    date.getMonth() < 9 ? '0' : ''
-  }${date.getMonth() + 1}`
+  // Get the current month in YYYY-MM-01 format
+  const currentMonth = `${new Date(Date.now())
+    .toISOString()
+    .substring(0, 7)}-01`
 
   it('can switch between the months', () => {
+    cy.getByTitle('Select Month').first().click()
     cy.get('#month').should('have.value', currentMonth)
 
     cy.visit('#', { qs: { month: '2020-02' } })
-    cy.get('#month').should('have.value', '2020-02')
+    cy.contains('February 2020')
     cy.contains('Mar')
 
     cy.contains('Jan').click()
     cy.contains('Dec').click()
 
-    cy.get('#month').should('have.value', '2019-12')
+    cy.contains('December 2019')
     cy.url().should('include', '?month=2019-12')
 
-    cy.get('#month').click()
-    cy.get('input#month').type('2022-03')
+    cy.getByTitle('Select Month').first().click()
+
+    cy.get('input#month').type('2022-03-01')
+    cy.getByTitle('March 2022').first().click()
     cy.awaitLoading()
-    cy.get('#month').should('have.value', '2022-03')
+    cy.contains('March 2022')
     cy.contains('Feb')
     cy.contains('Apr')
   })
@@ -216,6 +219,7 @@ describe('Dashboard', () => {
   })
 
   it('can quickly allocate funds to all envelopes', () => {
+    cy.getByTitle('Select Month').first().click()
     cy.get('#month').should('have.value', currentMonth)
     cy.visit('#', { qs: { month: '2023-04' } })
     cy.awaitLoading()

--- a/cypress/e2e/transaction-import.cy.ts
+++ b/cypress/e2e/transaction-import.cy.ts
@@ -154,7 +154,7 @@ describe('Transaction Import', () => {
 
     // Now at the last transaction, import this too
     cy.contains('5 of 5')
-    cy.getInputFor('Available From').should('have.value', '2023-06')
+    cy.getInputFor('Available From').should('have.value', '2023-06-01')
     cy.get('button').contains('Import').click()
 
     // Now back at the second transactions since we skipped it

--- a/cypress/e2e/transactions.cy.ts
+++ b/cypress/e2e/transactions.cy.ts
@@ -10,9 +10,11 @@ import { dateFromIsoString } from '../../src/lib/dates'
 
 describe('Transactions', () => {
   const date = new Date()
-  const currentMonth = `${date.getFullYear()}-${
-    date.getMonth() < 9 ? '0' : ''
-  }${date.getMonth() + 1}`
+
+  // Get the current month in YYYY-MM-01 format
+  const currentMonth = `${new Date(Date.now())
+    .toISOString()
+    .substring(0, 7)}-01`
 
   beforeEach(() => {
     // prepare a budget with two internal & one external accounts

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -5,7 +5,7 @@ volumes:
 
 services:
   backend:
-    image: ghcr.io/envelope-zero/backend:v5.1.0
+    image: ghcr.io/envelope-zero/backend:v5.1.3
     user: root
     volumes:
       - ez-dev-data:/data

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -5,7 +5,7 @@ volumes:
 
 services:
   backend:
-    image: ghcr.io/envelope-zero/backend:v5.1.0
+    image: ghcr.io/envelope-zero/backend:v5.1.3
     user: root
     volumes:
       - ez-production-data:/data

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   backend:
-    image: ghcr.io/envelope-zero/backend:v5.1.0
+    image: ghcr.io/envelope-zero/backend:v5.1.3
     user: root
     ports:
       - 8081:8080

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "envelope-zero-frontend",
       "hasInstallScript": true,
       "dependencies": {
-        "@envelope-zero/ynap-parsers": "1.17.1",
+        "@envelope-zero/ynap-parsers": "1.17.3",
         "@headlessui/react": "1.7.18",
         "@heroicons/react": "2.1.1",
         "@tailwindcss/forms": "0.5.7",
@@ -2432,12 +2432,11 @@
       "integrity": "sha512-/crHGujo0xnuHIYNc1VgP0HGJGFSoSqq88JFXe6FmFyXPpWt8Xu39LyLg7rchsxfXFeEdA9CrIZvLV5eswXV5g=="
     },
     "node_modules/@envelope-zero/ynap-bank2ynab-converter": {
-      "version": "1.14.39",
-      "resolved": "https://npm.pkg.github.com/download/@envelope-zero/ynap-bank2ynab-converter/1.14.39/e6ae652b9e6f4f4a5a78b4c90f07f7e050f7e9fb",
-      "integrity": "sha512-5ygoRYwfTk8TtGrxou9xRoMuixcv7QcsiyjZsm5lsV25qxhQs6AMaeku/8se+5GGu9/Der2p8BAc1goWlEdVqQ==",
-      "license": "MIT",
+      "version": "1.14.85",
+      "resolved": "https://registry.npmjs.org/@envelope-zero/ynap-bank2ynab-converter/-/ynap-bank2ynab-converter-1.14.85.tgz",
+      "integrity": "sha512-0w+5LkUrMg3tNM+WB/afMVAd7WCQPg+Rnfh2W1QFJqi6ZvzLO5BTs8a8iWZsv8p3gYN/EGwg0IJnnJwjDRqhvQ==",
       "dependencies": {
-        "commander": "11.1.0",
+        "commander": "12.0.0",
         "encoding": "0.1.13",
         "node-fetch": "2.7.0"
       },
@@ -2446,19 +2445,19 @@
       }
     },
     "node_modules/@envelope-zero/ynap-bank2ynab-converter/node_modules/commander": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
-      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.0.0.tgz",
+      "integrity": "sha512-MwVNWlYjDTtOjX5PiD7o5pK0UrFU/OYgcJfjjK4RaHZETNtjJqrZa9Y9ds88+A+f+d5lv+561eZ+yCKoS3gbAA==",
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/@envelope-zero/ynap-parsers": {
-      "version": "1.17.1",
-      "resolved": "https://npm.pkg.github.com/download/@envelope-zero/ynap-parsers/1.17.1/531f91debdff73e12f1de0b535f2ba5481f218b1",
-      "integrity": "sha512-ETPR+o8vfBgjOfdjqURm+1FezH98z8pCcrB1nRsHiSUrw/XYbYCFgzgyk+CYvHh/exC/j4pTUyWDr6F4GoBXjA==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@envelope-zero/ynap-parsers/-/ynap-parsers-1.17.3.tgz",
+      "integrity": "sha512-dZlZQrbDwiA/P494QlECRKAkiiw2cny51y0kXErIDcE42ksrjQ8wAE2+TGYi6Bp9QcimaA+1gzGiHthx5RS7aQ==",
       "dependencies": {
-        "@envelope-zero/ynap-bank2ynab-converter": "1.14.39",
+        "@envelope-zero/ynap-bank2ynab-converter": "1.14.85",
         "buffer": "6.0.3",
         "date-fns": "3.3.1",
         "iban": "0.0.14",
@@ -5664,9 +5663,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001578",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001578.tgz",
-      "integrity": "sha512-J/jkFgsQ3NEl4w2lCoM9ZPxrD+FoBNJ7uJUpGVjIg/j0OwJosWM36EPDv+Yyi0V4twBk9pPmlFS+PLykgEvUmg==",
+      "version": "1.0.30001591",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001591.tgz",
+      "integrity": "sha512-PCzRMei/vXjJyL5mJtzNiUCKP59dm8Apqc3PH8gJkMnMXZGox93RbE76jHsmLwmIo6/3nsYIpJtx0O7u5PqFuQ==",
       "funding": [
         {
           "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "envelope-zero-frontend",
   "dependencies": {
-    "@envelope-zero/ynap-parsers": "1.17.1",
+    "@envelope-zero/ynap-parsers": "1.17.3",
     "@headlessui/react": "1.7.18",
     "@heroicons/react": "2.1.1",
     "@tailwindcss/forms": "0.5.7",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "server:dev": "docker-compose --project-name frontend-dev --file docker-compose-dev.yml up",
     "server:test": "docker-compose --project-name frontend-test --file docker-compose-test.yml up",
     "server:production": "docker-compose --project-name frontend-production --file docker-compose-production.yml up --build",
-    "test": "cypress run --browser chromium",
+    "test": "cypress run",
     "test:watch": "cypress open",
     "format": "prettier --write .",
     "postinstall": "patch-package"


### PR DESCRIPTION
This will make maintenance and contributions easier.

Since envelope-zero/you-need-a-parser now publishes exclusively to npmjs, we need to update this anyways.

Resolves #1559.