### PR TITLE
fix: consider income in recent envelopes

### DIFF
--- a/src/components/TransactionForm.tsx
+++ b/src/components/TransactionForm.tsx
@@ -316,12 +316,19 @@ const TransactionForm = ({ budget, setNotification }: Props) => {
                     // Fetch the recent envelopes and suggest the first one
                     // as the Envelope to use for this transaction
                     envelopePromises.push(
-                      get(account.links.recentEnvelopes).then(data => {
-                        setRecentEnvelopes(data)
-                        if (data.length) {
-                          valuesToUpdate.envelopeId = data[0].id
+                      get(account.links.recentEnvelopes).then(
+                        (data: RecentEnvelope[]) => {
+                          // We use the first envelope in recent envelopes as suggestion
+                          // if its ID is not null. If its ID is null, income is the most
+                          // common "envelope" for this account, so we don't set it.
+                          if (data.length && data[0].id !== null) {
+                            valuesToUpdate.envelopeId = data[0].id
+                          }
+
+                          // Remove income from the recent envelopes
+                          setRecentEnvelopes(data.filter(e => e.id !== null))
                         }
-                      })
+                      )
                     )
                   } else if (!account.external) {
                     setRecentEnvelopes([])

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -183,5 +183,5 @@ export type QuickAllocationMode =
 
 export type RecentEnvelope = {
   name: string
-  id: UUID
+  id: UUID | null
 }


### PR DESCRIPTION
With this, income is considered in the recent envelopes.

In the recent envelopes, income is represented as a recent envelope with the ID `null`.

Therefore, we need to check for this specific case and not use it as suggestion when it is the first
in the list of recent envelopes.

We also need to remove it from the recent envelopes list.
