### PR TITLE
ci: enable merge groups

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -15,6 +15,9 @@ on:
   # Enables us to manually trigger the CI for earlier tags
   workflow_dispatch:
 
+  # Enable merge queue
+  merge_group:
+
 concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Enables merge group in the workflow to make it easier to merge multiple PRs.
