### PR TITLE
ci: fix cypress check names

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -216,3 +216,17 @@ jobs:
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+
+  cypress-merge-queue:
+    name: 'cypress: default-group (merge)'
+    if: github.event_name == 'merge_group'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "This does not do anything, it just fixes the required checks for cypress, since the Status checks are reported differently for the merge queue and the PRs"
+
+  cypress-pr:
+    name: 'cypress: default-group'
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "This does not do anything, it just fixes the required checks for cypress, since the Status checks are reported differently for the merge queue and the PRs"


### PR DESCRIPTION
With these checks added, we can use the merge queue together with cypress.

Unfortunately, cypress publishes the status checks as "cypress: default-group (merge)" for a PR and "cypress: default-group" in the merge queue. 

Therefore we need to have a successful job for the respective other name in our workflow.
