### PR TITLE
chore: update renovate config to remove encrypted config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -56,9 +56,7 @@
       "description": "See https://docs.renovatebot.com/getting-started/private-packages/#automatically-authenticate-for-npm-package-stored-in-private-github-npm-repository",
       "matchHost": "https://npm.pkg.github.com",
       "hostType": "npm",
-      "encrypted": {
-        "token": "{{ secrets.GITHUB_NPM_REGISTRY }}"
-      }
+      "token": "{{ secrets.GITHUB_NPM_REGISTRY }}"
     }
   ]
 }


### PR DESCRIPTION
With this, the renovate config should be correct again.
