### PR TITLE
chore: fix Dockerfile deprecations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:22.11.0-alpine AS builder
-ENV NODE_ENV production
+ENV NODE_ENV=production
 WORKDIR /app
 
 # copy package.json first to avoid unnecessary npm install when other files change
@@ -20,7 +20,7 @@ RUN npm run build
 
 # Bundle static assets with nginx
 FROM nginx:1.27.2-alpine
-ENV NODE_ENV production
+ENV NODE_ENV=production
 
 COPY default.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /app/dist /usr/share/nginx/html


### PR DESCRIPTION
Fixes the deprecated `ENV key value` format, using `ENV key=value` instead.
