### PR TITLE
chore(renovate): only rebase when needed

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,7 @@
   },
   "labels": ["renovate"],
   "rangeStrategy": "pin",
-  "rebaseWhen": "behind-base-branch",
+  "rebaseWhen": "conflicted",
   "semanticCommits": "enabled",
   "packageRules": [
     {


### PR DESCRIPTION
We need to rebase only when a PR is conflicted, since the merge queue enforces tests with up-to-date config.