### PR TITLE
fix: set availableFrom to next month on import

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -54,7 +54,7 @@ jobs:
     # Current backend version as service container
     services:
       backend:
-        image: ghcr.io/envelope-zero/backend:v6.0.1
+        image: ghcr.io/envelope-zero/backend:v6.0.3
         env:
           CORS_ALLOW_ORIGINS: http://localhost:3000
           API_URL: http://localhost:3000/api

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -5,7 +5,7 @@ volumes:
 
 services:
   backend:
-    image: ghcr.io/envelope-zero/backend:v6.0.1
+    image: ghcr.io/envelope-zero/backend:v6.0.3
     user: root
     volumes:
       - ez-dev-data:/data

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -5,7 +5,7 @@ volumes:
 
 services:
   backend:
-    image: ghcr.io/envelope-zero/backend:v6.0.1
+    image: ghcr.io/envelope-zero/backend:v6.0.3
     user: root
     volumes:
       - ez-production-data:/data

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   backend:
-    image: ghcr.io/envelope-zero/backend:v6.0.1
+    image: ghcr.io/envelope-zero/backend:v6.0.3
     user: root
     ports:
       - 8081:8080

--- a/src/components/TransactionImport/Result.tsx
+++ b/src/components/TransactionImport/Result.tsx
@@ -12,6 +12,7 @@ import {
   Category,
   Envelope,
   UnpersistedAccount,
+  UnpersistedTransaction,
 } from '../../types'
 import { CheckCircleIcon, XCircleIcon } from '@heroicons/react/24/outline'
 import FormFields from '../FormFields'
@@ -161,6 +162,20 @@ const Result = (props: Props) => {
       ...transactions[currentIndex].transaction,
       [name]: value,
     }
+    setTransactions(tmpTransactions)
+  }
+
+  const updateValues = (
+    values: { key: keyof UnpersistedTransaction; value: any }[]
+  ) => {
+    const tmpTransactions = [...transactions]
+
+    const newTransaction = tmpTransactions[currentIndex].transaction
+    values.forEach(value => {
+      newTransaction[value.key] = value.value
+    })
+
+    tmpTransactions[currentIndex].transaction = newTransaction
     setTransactions(tmpTransactions)
   }
 
@@ -422,7 +437,15 @@ const Result = (props: Props) => {
               onChange={e => {
                 // value is empty string for invalid dates (e.g. when prefixing month with 0 while typing) – we want to ignore that and keep the previous input
                 if (e.target.value) {
-                  updateValue('date', dateToIsoString(e.target.value))
+                  updateValues([
+                    { key: 'date', value: dateToIsoString(e.target.value) },
+                    {
+                      key: 'availableFrom',
+                      value: dateToIsoString(
+                        setToFirstOfNextMonth(e.target.value)
+                      ),
+                    },
+                  ])
                 }
               }}
             />
@@ -436,11 +459,12 @@ const Result = (props: Props) => {
                 tooltip={t('transactions.availableFromExplanation')}
                 value={(isSupported.inputTypeMonth()
                   ? (date: string) => monthYearFromDate(new Date(date))
-                  : (date: string) =>
-                      setToFirstOfNextMonth(dateFromIsoString(date)))(
-                  currentTransaction().availableFrom ||
-                    currentTransaction().date ||
-                    new Date().toISOString()
+                  : (date: string) => date)(
+                  dateFromIsoString(currentTransaction().availableFrom || '') ||
+                    setToFirstOfNextMonth(
+                      dateFromIsoString(currentTransaction().date || '') ||
+                        new Date().toISOString()
+                    )
                 )}
                 onChange={e => {
                   // value is empty string for invalid dates (e.g. when prefixing month with 0 while typing) – we want to ignore that and keep the previous input


### PR DESCRIPTION
This PR sets the availableFrom month to the next month by default for imports.

I missed this in 52df7a4b50606c1c19994377715771f8a6a44c6a, so with this commit created transactions and imports behave the same again.

This also fixes a bug where the import form correctly displayed the next month as availableFrom, but the transaction was imported incorrectly.
