### PR TITLE
ci: disable renovate limiting

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,8 @@
     "replacements:all",
     "workarounds:all",
     "helpers:pinGitHubActionDigests",
-    ":ignoreModulesAndTests"
+    ":ignoreModulesAndTests",
+    ":disableRateLimiting"
   ],
   "dependencyDashboard": true,
   "platformAutomerge": true,


### PR DESCRIPTION
Since updates might sometimes be blocked by other updates that are rate-limited, we're disabling the rate limiting.
