### PR TITLE
ci: run current prettier version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,10 +7,13 @@ repos:
         files: \.[jt]sx?$ # *.js, *.jsx, *.ts and *.tsx
         types: [file]
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.1.0
+  - repo: local
     hooks:
       - id: prettier
+        name: prettier
+        language: node
+        pass_filenames: false
+        entry: npm run format
 
   # Explicitly not using the renovate upstream hook because for some reason installing it is
   # excruciatingly slow (> 10 minutes in some cases)

--- a/index.html
+++ b/index.html
@@ -2,20 +2,28 @@
 <html lang="en" class="h-full">
   <head>
     <meta charset="utf-8" />
+
     <link rel="icon" href="/favicon.ico" />
+
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+
     <meta name="theme-color" content="rgb(153 27 27)" />
+
     <meta
       name="description"
       content="Envelope based zero sum budgeting for your personal needs."
     />
+
     <link rel="apple-touch-icon" href="/logo192.png" />
+
     <link rel="manifest" href="/manifest.json" />
+
     <title>Envelope Zero</title>
   </head>
   <body class="h-full">
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root" class="min-h-full"></div>
+
     <script type="module" src="/src/index.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
The pre-commit prettier hook does not work anymore, so we run prettier as a local hook.
