### PR TITLE
chore(deps): replace instead of pin npm version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -50,6 +50,11 @@
       "description": "Group eslint updates",
       "groupName": "eslint",
       "matchDepNames": ["pre-commit/mirrors-eslint", "eslint"]
+    },
+    {
+      "description": "Replace range for npm instead of pinning, to not require us to install specific npm versions",
+      "matchDepNames": ["npm"],
+      "rangeStrategy": "replace"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
See https://docs.renovatebot.com/configuration-options/#rangestrategy for details:

> replace = Replace the range with a newer one if the new version falls outside it, and update nothing otherwise
