### PR TITLE
fix: available from date and daylight savings time

### DIFF
--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -30,7 +30,15 @@ const setToFirstOfTheMonth = (date: string) => {
 
 const setToFirstOfNextMonth = (date: string) => {
   const d = new Date(date)
+
+  // Because timezones and dates are fucked, we set the hours to 12 so that daylight savings
+  // does not suddenly change the date
+  d.setHours(12)
+
+  // Set to the first
   d.setDate(1)
+
+  // Set to the next month
   d.setMonth(d.getMonth() + 1)
 
   // Return date in YYYY-MM-DD format


### PR DESCRIPTION
This fixes a bug where the next month was not correctly calculated during the month on which daylight savings time goes into effect.
As far as I'm aware, that month is March everywhere.

This only affected the "Available From" setting for income transactions for frontend versions 4.0.0 and newer, and only if these transactions were created between midnight and 01:00 your local time.

If you are using the frontend in version 4.0.0 or newer and have created transactions between midnight and 01:00 in March 2025, please verify that the Available From date is correct for those transactions.
