### PR TITLE
fix: no longer show "Untitled Account" on import when account is not known

### DIFF
--- a/cypress/e2e/transaction-import.cy.ts
+++ b/cypress/e2e/transaction-import.cy.ts
@@ -234,4 +234,36 @@ describe('Transaction Import', () => {
     cy.contains('Submit').click()
     cy.contains('This file can not be parsed.')
   })
+
+  // This is a regression test for "Untitled Account" being displayed as the source/destination account name
+  // See https://github.com/envelope-zero/frontend/issues/1763
+  it('shows an empty account name if it is unset', function () {
+    cy.get('nav').contains('Transactions').click()
+    cy.getByTitle('Import Transactions').click()
+    cy.awaitLoading()
+
+    cy.getAutocompleteFor('Account').type('account')
+    cy.contains('My Account').click()
+
+    cy.getInputFor('File').selectFile(
+      'cypress/fixtures/import-untitled-account.csv'
+    )
+
+    cy.contains('Submit').click()
+
+    // Verify that the Source account is not "Untitled Account", but empty
+    cy.getAutocompleteFor('Source')
+      .should('have.value', '')
+      .type('External Acc{enter}')
+    cy.get('button').contains('Import').click()
+
+    // Verify that the Source account is not "Untitled Account", but empty
+    cy.getAutocompleteFor('Destination')
+      .should('have.value', '')
+      .type('External Acc{enter}')
+    cy.get('button').contains('Import').click()
+
+    // Import should be finished
+    cy.contains('Import complete')
+  })
 })

--- a/cypress/fixtures/import-untitled-account.csv
+++ b/cypress/fixtures/import-untitled-account.csv
@@ -1,0 +1,10 @@
+;
+"Umsätze Girokonto - 12345678";"Zeitraum: 01.02.2025 - 09.02.2025";
+"Neuer Kontostand";"1.312,00 EUR";
+
+"Buchungstag";"Wertstellung (Valuta)";"Vorgang";"Buchungstext";"Umsatz in EUR";
+"03.02.2025";"03.02.2025";"Kartenverfügung";" Buchungstext: Some Merchant, Reimbursement ";"10,00";
+"07.02.2025";"07.02.2025";"Kartenverfügung";" Buchungstext: Some Other Merchant, Spending";"-3,50";
+
+"Alter Kontostand";"161,00 EUR";
+

--- a/src/components/TransactionImport/Result.tsx
+++ b/src/components/TransactionImport/Result.tsx
@@ -104,19 +104,23 @@ const Result = (props: Props) => {
     const transactionPreview = transactions[currentIndex]
     const { transaction } = transactionPreview
 
-    if (!accounts.some(account => account.id === transaction.sourceAccountId)) {
+    if (
+      transactionPreview.sourceAccountName &&
+      !accounts.some(account => account.id === transaction.sourceAccountId)
+    ) {
       setSourceAccountToCreate({
-        name: transactionPreview.sourceAccountName || '',
+        name: transactionPreview.sourceAccountName,
       })
     } else {
       setSourceAccountToCreate(undefined)
     }
 
     if (
+      transactionPreview.destinationAccountName &&
       !accounts.some(account => account.id === transaction.destinationAccountId)
     ) {
       setDestinationAccountToCreate({
-        name: transactionPreview.destinationAccountName || '',
+        name: transactionPreview.destinationAccountName,
       })
     } else {
       setDestinationAccountToCreate(undefined)


### PR DESCRIPTION
This fixes a bug where when the source or destination account could not be parsed on import and was not matched by any match rule, it was shown as "Untitled Account".

Resolves https://github.com/envelope-zero/frontend/issues/1763
